### PR TITLE
fix: handle null localStorage value for 'favoritos'

### DIFF
--- a/src/app/car/[id]/page.js
+++ b/src/app/car/[id]/page.js
@@ -37,11 +37,12 @@ export default function CarDetails({ params }) {
 
   if (!car) return <Loading />;
 
+  const favoritos = JSON.parse(localStorage.getItem("favoritos")) || [];
+
   return (
     <>
       <section className={styles.car__hero}>
-        {JSON.parse(localStorage.getItem("favoritos")).some(
-          (favorite) => favorite.id === id
+        {favoritos.some((car) => car.id === id
         ) && (
           <div
             onClick={removeCar}


### PR DESCRIPTION
This commit does a check to ensure that favorites is an empty array [] if localStorage.getItem("favorites") returns null. This prevents errors and allows the code to continue working even when there are no favorites stored in localStorage.